### PR TITLE
Add Organization parameter to initialization notification

### DIFF
--- a/internal/notification/handlers/queries.go
+++ b/internal/notification/handlers/queries.go
@@ -24,6 +24,7 @@ type Queries interface {
 	SMTPConfigByAggregateID(ctx context.Context, aggregateID string) (*query.SMTPConfig, error)
 	GetDefaultLanguage(ctx context.Context) language.Tag
 	GetInstanceRestrictions(ctx context.Context) (restrictions query.Restrictions, err error)
+	OrgByID(ctx context.Context, shouldTriggerBulk bool, id string) (org *query.Org, err error)
 }
 
 type NotificationQueries struct {

--- a/internal/notification/handlers/user_notifier.go
+++ b/internal/notification/handlers/user_notifier.go
@@ -163,13 +163,17 @@ func (u *userNotifier) reduceInitCodeAdded(event eventstore.Event) (*handler.Sta
 		if err != nil {
 			return err
 		}
+		org, err := u.queries.OrgByID(ctx, false, e.Aggregate().ResourceOwner)
+		if err != nil {
+			return err
+		}
 
 		ctx, err = u.queries.Origin(ctx, e)
 		if err != nil {
 			return err
 		}
 		err = types.SendEmail(ctx, u.channels, string(template.Template), translator, notifyUser, colors, e).
-			SendUserInitCode(ctx, notifyUser, code)
+			SendUserInitCode(ctx, notifyUser, code, org.Name)
 		if err != nil {
 			return err
 		}

--- a/internal/notification/types/init_code.go
+++ b/internal/notification/types/init_code.go
@@ -9,9 +9,10 @@ import (
 	"github.com/zitadel/zitadel/internal/query"
 )
 
-func (notify Notify) SendUserInitCode(ctx context.Context, user *query.NotifyUser, code string) error {
+func (notify Notify) SendUserInitCode(ctx context.Context, user *query.NotifyUser, code string, orgName string) error {
 	url := login.InitUserLink(http_utils.ComposedOrigin(ctx), user.ID, user.PreferredLoginName, code, user.ResourceOwner, user.PasswordSet)
 	args := make(map[string]interface{})
 	args["Code"] = code
+	args["Organization"] = orgName
 	return notify(url, args, domain.InitCodeMessageType, true)
 }


### PR DESCRIPTION
Adds the Organization name as a text message parameter to the initialization notification (sms or email)